### PR TITLE
Fix realKEGGIDs substr index

### DIFF
--- a/R/GOTerms.R
+++ b/R/GOTerms.R
@@ -293,7 +293,7 @@ setMethod("getGOFrameData", "GOAllFrame", function(x){x@data})
     ##Test that some KEGGIDs are real and that the evidence codes are legit.
     KEGGIDs <- x[,1]
     kegg_query <- data.frame(keggList("pathway"))
-    realKEGGIDs <- substr(rownames(kegg_query), 9, 13)
+    realKEGGIDs <- substr(rownames(kegg_query), 4, 9)
 
     ##Test that the data.frame has some rows of data in it
     if(!dim(x)[1]>0){

--- a/R/GOTerms.R
+++ b/R/GOTerms.R
@@ -299,7 +299,7 @@ setMethod("getGOFrameData", "GOAllFrame", function(x){x@data})
     if(!dim(x)[1]>0){
       stop("There are no rows of data in the data.frame supplied to make a KEGGFrame.")
     }
-    if(is.na(table(KEGGIDs %in% realKEGGIDs)["TRUE"])){
+    if(!any(KEGGIDs %in% realKEGGIDs)){
       stop("None of elements in the 1st column of your data.frame object are legitimate KEGG IDs.")
     }
     if(length(x[,1]) != length(x[,2])){ ## TODO, I don't think that this is going to test this effectively...  I probbaly need a different test.


### PR DESCRIPTION
This fix addresses the following error in the build report when running `R CMD check`:

```
* checking examples ... ERROR
Running examples in ‘AnnotationDbi-Ex.R’ failed
The error most likely occurred in:

> base::assign(".ptime", proc.time(), pos = "CheckExEnv")
> ### Name: KEGGFrame
> ### Title: KEGGFrame objects
> ### Aliases: KEGGFrame class:KEGGFrame KEGGFrame-class KEGGFrame
> ###   KEGGFrame,data.frame,character-method
> ###   KEGGFrame,data.frame,missing-method getKEGGFrameData
> ###   getKEGGFrameData,KEGGFrame-method
> ###   getKEGGFrameData,KEGGAllFrame-method
> ### Keywords: classes interface
> 
> ### ** Examples
> 
>   ## Make up an example
>   genes = c(2,9,9,10)
>   KEGGIds = c("04610","00232","00983","00232")
>   frameData = data.frame(cbind(KEGGIds,genes))=-
> 
>   library(AnnotationDbi)
>   frame=KEGGFrame(frameData,organism="Homo sapiens")
Error in KEGGFrame(frameData, organism = "Homo sapiens") : 
  None of elements in the 1st column of your data.frame object are legitimate KEGG IDs.
Calls: KEGGFrame -> KEGGFrame
Execution halted
```

The error is on both release and devel (https://bioconductor.org/checkResults/3.17/bioc-LATEST/AnnotationDbi/nebbiolo1-checksrc.html).

It seems that it was checking the wrong indexes (maybe it was changed in the KEGG API?) as `kegg_query` produced 

```
> kegg_query                                                                                                           
                                                                     keggList..pathway..                               
map01100                                                              Metabolic pathways                               
map01110                                           Biosynthesis of secondary metabolites                               
map01120                                    Microbial metabolism in diverse environments                               
map01200                                                               Carbon metabolism                               
map01210                                                 2-Oxocarboxylic acid metabolism                               
map01212                                                           Fatty acid metabolism                               
```

Checking the wrong index gave `realKEGGIDs` blank values.